### PR TITLE
Fix for getForeignKeys()/getAllForeignKeys() methods

### DIFF
--- a/dts/metadata.d.ts
+++ b/dts/metadata.d.ts
@@ -13,6 +13,8 @@ export interface IClientMetadata {
 
   getLookupTypes (resourceId: string, field: string): Promise<IGetTableResponse>
 
+  getForeignKeys (resourceId: string): Promise<IGetTableResponse>
+
   getAllClass (): Promise<IGetTableResponse>
 
   getAllTable (): Promise<IGetTableResponse>
@@ -22,6 +24,8 @@ export interface IClientMetadata {
   getAllLookups (): Promise<IGetTableResponse>
 
   getAllLookupTypes (): Promise<MetadataLookupTypes>
+
+  getAllForeignKeys (): Promise<IGetTableResponse>
 }
 
 interface MetadataLookupTypes {

--- a/lib/clientModules/metadata.coffee
+++ b/lib/clientModules/metadata.coffee
@@ -146,13 +146,13 @@ module.exports = (_retsSession, _client) ->
   getMetadata: getMetadata
   getSystem: getSystem
   getResources:       _getParsedMetadataFactory('METADATA-RESOURCE').bind(null, '0')
-  getForeignKeys:     _getParsedMetadataFactory('METADATA-FOREIGNKEYS')
+  getForeignKeys:     _getParsedMetadataFactory('METADATA-FOREIGN_KEYS')
   getClass:           _getParsedMetadataFactory('METADATA-CLASS')
   getTable:           _getParsedMetadataFactory('METADATA-TABLE')
   getLookups:         _getParsedMetadataFactory('METADATA-LOOKUP')
   getLookupTypes:     _getParsedMetadataFactory('METADATA-LOOKUP_TYPE')
   getObject:          _getParsedMetadataFactory('METADATA-OBJECT')
-  getAllForeignKeys:  _getParsedAllMetadataFactory('METADATA-FOREIGNKEYS')
+  getAllForeignKeys:  _getParsedAllMetadataFactory('METADATA-FOREIGN_KEYS')
   getAllClass:        _getParsedAllMetadataFactory('METADATA-CLASS')
   getAllTable:        _getParsedAllMetadataFactory('METADATA-TABLE')
   getAllLookups:      _getParsedAllMetadataFactory('METADATA-LOOKUP')


### PR DESCRIPTION
Hello! This PR changes "METADATA-FOREIGNKEYS" to "METADATA-FOREIGN_KEYS" in metadata.coffee. Per _RCP 87 - RETS 1.7.2 Errata Document_, the latter is the correct value:

> #### Erratum 8
>
> The Foreign Key Metadata element has an inconsistency in the 1.7.2. The tag label for the metadata content is referenced in three places. 
> METADATA-FOREIGN_KEYS is specified on page 11-9 of Section 11.2.3
> METADATA-FOREIGN_KEYS is specified in the RETS 1.7.2 DTD on page 6 in line 273
> METADATA-FOREIGNKEYS is specified on page B-2 of Appendix B-2
> It is also referenced in Table 11-12, Metadata Content, Field ForeignKeyName in the Description column as METADATA-FOREIGNKEYS. 
> The correct use is METADATA-FOREIGN_KEYS.

RCP 87 can be found in the [RETS 1.8 Specification](https://www.reso.org/rets-specifications/), Appendix E.

RETS servers I'm dealing with do respond with the foreign keys metadata table after this change.